### PR TITLE
Feat/run arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ W folderze głównym repozytorium uruchom:
 ```
 $ python -m blankiety_galantow
 ```
+### Dostępne opcje
+```
+usage: blankiety_galantow [-h] [--port PORT] [--host HOST]
+
+Run the app
+
+optional arguments:
+  -h, --help   show this help message and exit
+  --port PORT  Set port (default: 80)
+  --host HOST  Set host (default: localhost)
+```
 
 ## Zasady projektu
 Zajrzyj do [tego dokumentu](CONTRIBUTING.md).

--- a/blankiety_galantow/app.py
+++ b/blankiety_galantow/app.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import uvicorn
 from fastapi import FastAPI
@@ -29,4 +30,10 @@ server.add_room("Gamma")
 
 # Starting server using uvicorn
 def run():
-    uvicorn.run(app, host="localhost", port=80)
+    parser = argparse.ArgumentParser(prog="blankiety_galantow", description="Run the app")
+    parser.add_argument("--port", default=80, type=int, help="Set port (default: 80)")
+    parser.add_argument("--host", default="localhost", help="Set host (default: localhost)")
+
+    args = vars(parser.parse_args())
+    uvicorn.run(app, **args)
+

--- a/blankiety_galantow/resources/game/js/websocket_connect.js
+++ b/blankiety_galantow/resources/game/js/websocket_connect.js
@@ -3,5 +3,7 @@ function connect() {
     const parts = document.location.href.split('/');
     const game_id = parts[parts.length - 1];
     const username = window.localStorage.getItem("username") || "Bezimienny";
-    return new WebSocket("ws://localhost:80/connect/" + game_id + "?username=" + username);
+    const port = window.location.port ? ":" + window.location.port : "";
+    const webSocketUrl = "ws://localhost" + port + "/connect/" + game_id + "?username=" + username;
+    return new WebSocket(webSocketUrl);
 }


### PR DESCRIPTION
# Argumenty uruchamiania aplikacji
Dodałem wygodne argumenty, z którymi można uruchomić aplikację. Dostępne opcje są wypisane w automatycznie generowanej stronie pomocy:

```
$ python -m blankiety_galantow -h
```
![image](https://user-images.githubusercontent.com/19170699/81811925-b0289680-9525-11ea-98e0-0aaaf39c148a.png)

Domyślne argumenty to `80` na port i `localhost` na hosta.
### Przykład uruchomienia
```
python -m blankiety_galantow --port 4000
```
*Info dla osób odpalających z konsoli: Pamiętajcie, że przy używaniu venv trzeba użyć ścieżki `venv/Scripts/python`, aby odpalić skrypt (nie zwykłego `python`). Można też uruchomić skrypt `Activate` i wtedy da się używać `python`*

Teraz każdy może sobie lokalnie skonfigurować w PyCharm port, na którym chce działać, bo Run Configi nie są przesyłane do repo.
![image](https://user-images.githubusercontent.com/19170699/81812136-009ff400-9526-11ea-8b00-c7730b938ffe.png)

