### PR TITLE
Wypisywanie logów, usprawnienie debugowania

### DIFF
--- a/blankiety_galantow/app.py
+++ b/blankiety_galantow/app.py
@@ -34,6 +34,7 @@ def run():
     parser.add_argument("--port", default=80, type=int, help="Set port (default: 80)")
     parser.add_argument("--host", default="localhost", help="Set host (default: localhost)")
     parser.add_argument("--reload", default=False, type=bool, help="Enable auto reload (default: False)")
+    parser.add_argument("--log-level", default="info", help="Set log level: [info|debug|...] (default: info)")
 
     args = vars(parser.parse_args())
     uvicorn.run("blankiety_galantow.app:app", **args)

--- a/blankiety_galantow/core/deck.py
+++ b/blankiety_galantow/core/deck.py
@@ -1,11 +1,11 @@
 import csv
 import random
 
-class Deck:
 
-    def __init__(self, CardType, path):     
+class Deck:
+    def __init__(self, card_type, path: str):
         self.cards = list()
-        self.CardType = CardType
+        self.card_type = card_type
         self.path = path
         self.load_from_file()
         self.shuffle_cards()
@@ -14,8 +14,8 @@ class Deck:
         with open(self.path, mode='r', encoding='utf-8') as deck_csv:
             deck_reader = csv.DictReader(deck_csv, delimiter=';')
             
-            for id, row in enumerate(deck_reader):
-                new_card = self.CardType(id, row)
+            for counter, row in enumerate(deck_reader):
+                new_card = self.card_type(counter, row)
                 self.cards.append(new_card)
 
     def get_card(self):
@@ -33,13 +33,13 @@ class Deck:
 
 
 class WhiteCard:
-    def __init__(self, id, deck_reader):
-        self.id = id
-        self.text = deck_reader["treść"]
+    def __init__(self, card_id: int, data):
+        self.id: int = card_id
+        self.text: str = data["treść"]
 
 
 class BlackCard:
-    def __init__(self, id, deck_reader):
-        self.id = id
-        self.text = deck_reader["treść"]
-        self.gap_count = deck_reader["luki"]
+    def __init__(self, card_id: int, data):
+        self.id: int = card_id
+        self.text: str = data["treść"]
+        self.gap_count: int = data["luki"]

--- a/blankiety_galantow/core/room.py
+++ b/blankiety_galantow/core/room.py
@@ -1,6 +1,7 @@
 import random
 from typing import Dict
 from fastapi.websockets import WebSocketDisconnect
+from fastapi.logger import logger
 
 from .helpers import get_random_string
 from .player import Player
@@ -50,10 +51,10 @@ class Room:
     async def process_message(self, player: Player, data: Dict):
         """Process raw JSON message (data) from player."""
         if "type" not in data:
-            print(f"Received incorrect message: '{data}'")
+            logger.error(f"Received incorrect message: {data}")
             return
         if data["type"] == "ERROR" and "message" in data:
-            print(f"ERROR: {data['message']}")
+            logger.error(f"ERROR: {data}")
         if data["type"] == "CHAT_MESSAGE" and "message" in data:
             await self.send_chat_message_from_user(player.name, data["message"])
         # TODO: other types of messages

--- a/blankiety_galantow/routers.py
+++ b/blankiety_galantow/routers.py
@@ -2,6 +2,7 @@ import codecs
 
 from fastapi import APIRouter, WebSocket
 from fastapi.responses import HTMLResponse
+from fastapi.logger import logger
 
 import blankiety_galantow.app as app
 from .core.player import Player
@@ -27,7 +28,7 @@ async def websocket_endpoint(websocket: WebSocket, room_id: str, username: str):
         player = Player(websocket, username)
         await app.server.add_player_to_room(room_id, player)
     else:
-        print(f"Connection to nonexistent room id = {room_id}")
+        logger.error(f"Connection to nonexistent room id = {room_id}")
         await websocket.send_json({
             "type": "ERROR",
             "error": "Invalid server id"
@@ -40,8 +41,10 @@ async def rooms():
     room_list = app.server.get_room_list()
     return {"rooms": room_list}
 
+
 @router.get("/api/create")
 async def create_room(name: str, seats: int = 0):
     room_id = app.server.add_room(name, seats)
+    logger.info(f"Created new room called '{name}' with id {room_id}")
     return {"room_id": room_id}
 


### PR DESCRIPTION
Zamieniłem `print`y na wywołania logger'a, którego możemy włączać i wyłączać. Nowa opcja uruchomienia:
```
--log-level [critical|error|warning|info|debug|trace]
```
Domyślnie jest `info`. Opcje są ułożone w kolejności ważności, tzn. `--log-level info` znaczy, że konsola będzie wypisywała wiadomości typu `critical`, `error`, `warning` oraz `info`. Przydatną opcją jest `debug`, bo pokazuje JSON'y wysyłane i odbierane.

Branch dodaje też typowanie zmiennych w `deck.py`. Mam nadzieję, że nie spowoduje to konfliktu.

closes #21  