### PR TITLE
Zmiana nazwy pokoju

### DIFF
--- a/blankiety_galantow/core/room.py
+++ b/blankiety_galantow/core/room.py
@@ -105,6 +105,7 @@ class Room:
         settings_data = {
             "type": "SETTINGS",
             "settings": {
+                "roomName": self.settings.name,
                 "open": self.settings.open,
                 "time": self.settings.selecting_time,
                 "customCards": self.settings.custom_cards,

--- a/blankiety_galantow/core/room_settings.py
+++ b/blankiety_galantow/core/room_settings.py
@@ -14,7 +14,7 @@ class RoomSettings:
 
     async def update(self, who: str, data: dict):
         try:
-            # await self.set_name(who, data["roomName"])
+            await self.set_name(who, data["roomName"])
             await self.set_open(who, data["open"])
             await self.set_custom_cards(who, data["customCards"])
             await self.set_selecting_time(who, data["time"])

--- a/blankiety_galantow/resources/game/index.html
+++ b/blankiety_galantow/resources/game/index.html
@@ -51,7 +51,7 @@
                 <div class="w3-modal-content w3-card-4 w3-animate-zoom" style="max-width:600px">
 
                     <div class="w3-center"><br>
-                        <span @click="showSettings=false" class="w3-button w3-xlarge w3-transparent w3-display-topright" title="Zamknij">×</span>
+                        <span @click="cancelSettingsChanges" class="w3-button w3-xlarge w3-transparent w3-display-topright" title="Zamknij">×</span>
                         <h3>Ustawienia</h3>
                     </div>
                     <hr>
@@ -62,18 +62,25 @@
                             </p>
                         </div>
                         <p>
+                            <label>Nazwa pokoju
+                                <input class="w3-input" type="text" autocomplete="off" required
+                                        v-model="newSettings.roomName"
+                                        :disabled="!me.admin">
+                            </label>
+                        </p>
+                        <p>
                             <input id="is-open" name="is-open" class="w3-check" type="checkbox"
                                    :disabled="!me.admin"
-                                   v-model="settings.open">
+                                   v-model="newSettings.open">
                             <label for="is-open">Zezwól na dołączenie nowych graczy</label>
                         </p>
                         <h4>Tryb gry</h4>
                         <label>
-                            <input class="w3-radio" v-model="settings.gameType" type="radio" name="game-type" value="default" checked="" :disabled="!me.admin">
+                            <input class="w3-radio" v-model="newSettings.gameType" type="radio" name="game-type" value="default" checked="" :disabled="!me.admin">
                             Standardowy
                         </label><br>
                         <label>
-                            <input class="w3-radio" v-model="settings.gameType" type="radio" name="game-type" value="customcards" :disabled="!me.admin">
+                            <input class="w3-radio" v-model="newSettings.gameType" type="radio" name="game-type" value="customcards" :disabled="!me.admin">
                             Mydełko
                             <span class="tooltip">(?)
                                 <span class="tooltiptext">
@@ -82,13 +89,13 @@
                             </span>
                         </label><br>
                         <h4>Limit czasu</h4>
-                        <input type="number" v-model.number="settings.time" name="time-limit" id="time-limit" value="60" :disabled="!me.admin"> sek.
-                        <div v-if="settings.gameType == 'customcards'"><h4>Liczba własnych kart</h4>
-                            <input type="number" v-model.number="settings.customCards" name="custom-cards" id="custom-cards" value="5" :disabled="!me.admin">
+                        <input type="number" v-model.number="newSettings.time" name="time-limit" id="time-limit" value="60" :disabled="!me.admin"> sek.
+                        <div v-if="newSettings.gameType == 'customcards'"><h4>Liczba własnych kart</h4>
+                            <input type="number" v-model.number="newSettings.customCards" name="custom-cards" id="custom-cards" value="5" :disabled="!me.admin">
                         </div>
                     </div>
                     <div class="w3-container w3-border-top w3-padding-16 w3-light-grey">
-                        <button @click="showSettings=false" type="button" class="w3-button w3-red" >Anuluj</button>
+                        <button @click="cancelSettingsChanges" type="button" class="w3-button w3-red" >Anuluj</button>
                         <button @click="submitSettings" type="button" class="w3-button w3-green w3-right"
                                 :disabled="!me.admin">Zapisz</button>
                     </div>
@@ -207,7 +214,7 @@
             <div class="w3-third">
                 <div id="sidebar" class="w3-card w3-bar-block">
                     <div class="w3-container w3-bar-item" style="display: flex;">
-                        <h2 style="width: 100%;">Stół: {{ tableId }}</h2>
+                        <h2 style="width: 100%;">Pokój: {{ settings.roomName }}</h2>
                         <button class="w3-button" style="width: 100px;" @click="showSettings=true"><i class="icon-cog w3-xxxlarge"></i></button>
                     </div>
                     <button class="w3-button w3-bar-item w3-light-grey" @click="showPlayers = !showPlayers">Gracze <i class="icon-down-dir"></i></button>

--- a/blankiety_galantow/resources/game/js/main.js
+++ b/blankiety_galantow/resources/game/js/main.js
@@ -103,10 +103,14 @@ const app = new Vue({
         submitSettings: function() {
             const data = {
                 type: "SETTINGS",
-                settings: this.settings
+                settings: this.newSettings
             };
             socket.send(JSON.stringify(data));
             this.showSettings = false  // close settings modal
+        },
+        cancelSettingsChanges: function() {
+            this.newSettings = Object.assign({}, this.settings);
+            this.showSettings = false;
         },
         updateTimer: function() {
             this.timer = this.settings.time;
@@ -192,18 +196,19 @@ const app = new Vue({
         },
     },
     data: {
-        tableId: 20965,
         players: [],
         myCards: [],
         chat: [],
         newMessage: '',
         errorMessage: '',
         settings: {
+            roomName: "",
             customCards: 5,
             open: true,
             time: 60,
             gameType: "default"
         },
+        newSettings: {},
         showPlayers: false,
         showChat: true,
         showSettings: false,
@@ -223,7 +228,7 @@ setInterval(()=>{
     if(app.timer > 0 && app.players.length > 1){
         app.timer = app.timer - 1;
     }
-}, 1000)
+}, 1000);
 
 
 // Receive message from websocket
@@ -262,7 +267,7 @@ socket.onmessage = function(event) {
         app.updateTimer();
     }
     if(data.type === "SELECT_RANDOM_CARDS") {
-        app.selectedCards = []
+        app.selectedCards = [];
         for(const card of data.cards){
             app.selectCard(app.myCards.filter((myCard) => myCard.id === card.id)[0])
         }
@@ -272,6 +277,7 @@ socket.onmessage = function(event) {
     }
     if(data.type === "SETTINGS") {
         app.settings = data.settings;
+        app.newSettings = Object.assign({}, data.settings);
     }
     if(data.type === "KICK") {
         app.errorMessage = data.message;


### PR DESCRIPTION
Możliwa jest teraz zmiana nazwy pokoju.

![image](https://user-images.githubusercontent.com/19170699/83533329-bfc94880-a4ef-11ea-8c2d-9b50359efa4f.png)

Przy okazji naprawiłem pewnego buga, który był niewykryty. Musiałem utworzyć nowy obiekt `newSettings` zamiast bindować inputy ustawień do oryginalnego `settings`. Jak admin zmieniał ustawienia i nie dał "Zapisz", to on miał zmienione a inni nie. Teraz ustawienia zmieniane (`newSettings`) oraz te obowiązujące (`settings`), to oddzielne zmienne.

Oczywiście praktycznie żadne nasze inputy nie mają walidacji na backendzie, więc wpisanie Pana Tadeusza jako nazwę pokoju powinno przejść. Kiedyś się o tym pomyśli 😂.

To rozwiązuje taska #103 i przy okazji #50. (closes #103, closes #50)