### PR TITLE
Feat/password protection

### DIFF
--- a/blankiety_galantow/core/game_master.py
+++ b/blankiety_galantow/core/game_master.py
@@ -51,7 +51,7 @@ class GameMaster:
             self.timer.cancel()
         if player is self.master:
             self.set_new_random_master()
-            if len(self.players) > 0:
+            if len(self.players) > 1:
                 await self.chat.send_message_from_system(f"Gracz '{self.master.name}' zostaje Mistrzem Kart.")
                 self.timer_start()
         if self.all_players_ready():

--- a/blankiety_galantow/core/room.py
+++ b/blankiety_galantow/core/room.py
@@ -50,13 +50,18 @@ class Room:
                 "type": "PASSWORD"
             }
             await player.send_json(message)
+            player_valid = False
             while True:
                 msg = await player.receive_json()
                 if msg["type"] == "PASSWORD" and "password" in msg:
                     if msg["password"] == self.settings.password:
-                        await self.add_player(player)
-                    else:
-                        await player.kill("Nieprawidłowe hasło!")
+                        player_valid = True
+                    break
+            
+            if player_valid:
+                await self.add_player(player)
+            else:
+                await player.kill("Nieprawidłowe hasło!")
         except WebSocketDisconnect:
             pass
 

--- a/blankiety_galantow/core/room.py
+++ b/blankiety_galantow/core/room.py
@@ -26,7 +26,7 @@ class Room:
     def number_of_players(self):
         return len(self.players)
 
-    async def add_player_and_listen(self, player: Player):
+    async def connect_new_player(self, player: Player):
         """Add new player to the room and start listening."""
         if not self.settings.open:
             await player.kill("Pokój jest zamknięty.")
@@ -42,7 +42,7 @@ class Room:
         if self.settings.password != "":
             await self.listen_to_waiting_player(player)
         else:
-            await self.add_player(player)
+            await self.add_player_and_listen(player)
 
     async def listen_to_waiting_player(self, player: Player):
         try:
@@ -59,13 +59,13 @@ class Room:
                     break
             
             if player_valid:
-                await self.add_player(player)
+                await self.add_player_and_listen(player)
             else:
                 await player.kill("Nieprawidłowe hasło!")
         except WebSocketDisconnect:
             pass
 
-    async def add_player(self, player: Player):
+    async def add_player_and_listen(self, player: Player):
         player.id = self.generate_unique_player_id()
         await self.players.append(player)
 

--- a/blankiety_galantow/core/room.py
+++ b/blankiety_galantow/core/room.py
@@ -56,7 +56,7 @@ class Room:
                     if msg["password"] == self.settings.password:
                         await self.add_player(player)
                     else:
-                        await player.kill("Nieprawidłowe hasło!!!")
+                        await player.kill("Nieprawidłowe hasło!")
         except WebSocketDisconnect:
             pass
 

--- a/blankiety_galantow/core/room_settings.py
+++ b/blankiety_galantow/core/room_settings.py
@@ -11,6 +11,7 @@ class RoomSettings:
         self.selecting_time: int = 60
         self.game_type: str = "default"
         self.custom_cards: int = 5
+        self.password: str = ""
 
     async def update(self, who: str, data: dict):
         try:
@@ -19,6 +20,7 @@ class RoomSettings:
             await self.set_custom_cards(who, data["customCards"])
             await self.set_selecting_time(who, data["time"])
             await self.set_game_type(who, data["gameType"])
+            self.set_room_password(data["password"])
         except KeyError:
             logger.error(f"Received invalid settings: {data}")
 
@@ -55,3 +57,6 @@ class RoomSettings:
                 await self.chat.send_message_from_system(f"Admin {who} zmienił tryb gry na Standardowy.")
             elif self.game_type == "customcards":
                 await self.chat.send_message_from_system(f"Admin {who} zmienił tryb gry na Mydełko.")
+
+    def set_room_password(self, password):
+        self.password = password

--- a/blankiety_galantow/core/server.py
+++ b/blankiety_galantow/core/server.py
@@ -17,7 +17,7 @@ class Server:
 
     async def add_player_to_room(self, room_id: int, player: Player):
         """Add new player to existing room."""
-        await self._rooms[room_id].add_player_and_listen(player)
+        await self._rooms[room_id].connect_new_player(player)
 
     def add_room(self, name: str, seats: int = 0):
         """Add new room with random alpha-numeric id"""

--- a/blankiety_galantow/resources/game/css/main.css
+++ b/blankiety_galantow/resources/game/css/main.css
@@ -159,6 +159,11 @@
 #chat-input {
     width: 100%;
 }
+#stop-meme {
+    padding: 0.5em;
+    max-width:100%;
+    max-height:100%;
+}
 .info-box {
     margin-top: 0.3em;
     padding: 0.1em 0.3em;

--- a/blankiety_galantow/resources/game/css/main.css
+++ b/blankiety_galantow/resources/game/css/main.css
@@ -159,11 +159,6 @@
 #chat-input {
     width: 100%;
 }
-#stop-meme {
-    padding: 0.5em;
-    max-width:100%;
-    max-height:100%;
-}
 .info-box {
     margin-top: 0.3em;
     padding: 0.1em 0.3em;

--- a/blankiety_galantow/resources/game/index.html
+++ b/blankiety_galantow/resources/game/index.html
@@ -51,7 +51,7 @@
                     <h3>Podaj hasło do pokoju</h3>
                     <hr>
                     <p>
-                        Hasło: <input id="password" type="text" minlength="5" v-model="inputPassword">
+                        Hasło: <input id="password" type="text" v-model="inputPassword">
                     </p>
                 </div>
                 <div class="w3-container w3-border-top w3-padding-16 w3-light-grey">

--- a/blankiety_galantow/resources/game/index.html
+++ b/blankiety_galantow/resources/game/index.html
@@ -141,7 +141,8 @@
                     <div class="w3-container w3-border-top w3-padding-16 w3-light-grey">
                         <button @click="cancelSettingsChanges" type="button" class="w3-button w3-red" >Anuluj</button>
                         <button @click="submitSettings" type="button" class="w3-button w3-green w3-right"
-                                :disabled="!me.admin">Zapisz</button>
+                                :disabled="!me.admin ||
+                                (6 > newSettings.password.length && settingsPasswordRequired)">Zapisz</button>
                     </div>
                 </div>
             </div>

--- a/blankiety_galantow/resources/game/index.html
+++ b/blankiety_galantow/resources/game/index.html
@@ -102,7 +102,7 @@
                             <p v-if="settingsPasswordRequired" >
                                 Hasło: <input type="text" minlength="passwordLength" v-model="newSettings.password">
                             </p>
-                            <div v-if="passwordLength > newSettings.password.length && settingsPasswordRequired" style="text-align: center;">
+                            <div v-if="newSettings.password.length < passwordLength && settingsPasswordRequired" style="text-align: center;">
                                 <p style="color: red; font-style: italic; margin-top: 0">
                                     Hasło musi być dłuższe niż {{passwordLength}} znaki.
                                 </p>
@@ -133,7 +133,7 @@
                         <button @click="cancelSettingsChanges" type="button" class="w3-button w3-red" >Anuluj</button>
                         <button @click="submitSettings" type="button" class="w3-button w3-green w3-right"
                                 :disabled="!me.admin ||
-                                (passwordLength > newSettings.password.length && settingsPasswordRequired)">Zapisz</button>
+                                (newSettings.password.length < passwordLength && settingsPasswordRequired)">Zapisz</button>
                     </div>
                 </div>
             </div>

--- a/blankiety_galantow/resources/game/index.html
+++ b/blankiety_galantow/resources/game/index.html
@@ -67,6 +67,25 @@
                                    v-model="settings.open">
                             <label for="is-open">Zezwól na dołączenie nowych graczy</label>
                         </p>
+                        <p>
+                            <input v-if="me.admin" 
+                                id="is-password-protected" 
+                                name="is-password-protected" 
+                                class="w3-check" 
+                                type="checkbox"
+                                v-model="passwordProtected">
+                            <label for="is-password-protected">Zabezpieczenie hasłem</label>
+                            <p v-if="passwordProtected" >
+                                Hasło: <input type="text" minlength="5" v-model="settings.password">
+                                
+                            </p>
+                            <div v-if="!passwordValid" style="text-align: center;">
+                                <p style="color: red; font-style: italic; margin-top: 0">
+                                    Hasło musi być dłuższe niż 5 znaków.
+                                </p>
+                            </div>
+                            
+                        </p>
                         <h4>Tryb gry</h4>
                         <label>
                             <input class="w3-radio" v-model="settings.gameType" type="radio" name="game-type" value="default" checked="" :disabled="!me.admin">

--- a/blankiety_galantow/resources/game/index.html
+++ b/blankiety_galantow/resources/game/index.html
@@ -43,6 +43,28 @@
             </div>
         </div>
 
+        <!-- Password Modal -->
+        <div class="w3-modal on-top-modal" :class="{'w3-show': passwordRequired}">
+            <div class="w3-modal-content w3-card-4 w3-animate-zoom" style="max-width:600px">
+                <div class="w3-center"><br>
+                    <span v-on:click="exit()" class="w3-button w3-xlarge w3-transparent w3-display-topright" title="Close Modal">×</span>
+                    <h3>Podaj hasło do pokoju</h3>
+                    <hr>
+                    <p>
+                        Hasło: <input id="password" type="text" minlength="5" v-model="inputPassword">
+                    </p>
+                    <div v-if="!passwordValid" style="text-align: center;">
+                        <p style="color: red; font-style: italic; margin-top: 0">
+                            Hasło musi być dłuższe niż 5 znaków.
+                        </p>
+                    </div>
+                </div>
+                <div class="w3-container w3-border-top w3-padding-16 w3-light-grey">
+                    <button v-on:click="exit()" type="button" class="w3-button w3-red">Wyjdź</button>
+                    <button @click="submitPassword" type="button" class="w3-button w3-green w3-right">Potwierdź</button>
+                </div>
+            </div>
+        </div>
         <!-- Game App Content -->
         <template v-if="gameLoaded">
             <!-- Modal -->
@@ -67,19 +89,18 @@
                                    v-model="settings.open">
                             <label for="is-open">Zezwól na dołączenie nowych graczy</label>
                         </p>
-                        <p>
-                            <input v-if="me.admin" 
+                        <p  v-if="me.admin">
+                            <input 
                                 id="is-password-protected" 
                                 name="is-password-protected" 
                                 class="w3-check" 
                                 type="checkbox"
-                                v-model="passwordProtected">
+                                @change="changePasswordProtected($event)">
                             <label for="is-password-protected">Zabezpieczenie hasłem</label>
                             <p v-if="passwordProtected" >
                                 Hasło: <input type="text" minlength="5" v-model="settings.password">
-                                
                             </p>
-                            <div v-if="!passwordValid" style="text-align: center;">
+                            <div v-if="6 > settings.password.length && passwordProtected" style="text-align: center;">
                                 <p style="color: red; font-style: italic; margin-top: 0">
                                     Hasło musi być dłuższe niż 5 znaków.
                                 </p>

--- a/blankiety_galantow/resources/game/index.html
+++ b/blankiety_galantow/resources/game/index.html
@@ -100,11 +100,11 @@
                                 @change="changePasswordRequired($event)">
                             <label for="is-password-protected">Zabezpieczenie hasłem</label>
                             <p v-if="settingsPasswordRequired" >
-                                Hasło: <input type="text" minlength="5" v-model="newSettings.password">
+                                Hasło: <input type="text" minlength="passwordLength" v-model="newSettings.password">
                             </p>
-                            <div v-if="6 > newSettings.password.length && settingsPasswordRequired" style="text-align: center;">
+                            <div v-if="passwordLength > newSettings.password.length && settingsPasswordRequired" style="text-align: center;">
                                 <p style="color: red; font-style: italic; margin-top: 0">
-                                    Hasło musi być dłuższe niż 5 znaków.
+                                    Hasło musi być dłuższe niż {{passwordLength}} znaki.
                                 </p>
                             </div>
                             
@@ -133,7 +133,7 @@
                         <button @click="cancelSettingsChanges" type="button" class="w3-button w3-red" >Anuluj</button>
                         <button @click="submitSettings" type="button" class="w3-button w3-green w3-right"
                                 :disabled="!me.admin ||
-                                (6 > newSettings.password.length && settingsPasswordRequired)">Zapisz</button>
+                                (passwordLength > newSettings.password.length && settingsPasswordRequired)">Zapisz</button>
                     </div>
                 </div>
             </div>

--- a/blankiety_galantow/resources/game/index.html
+++ b/blankiety_galantow/resources/game/index.html
@@ -95,12 +95,12 @@
                                 name="is-password-protected" 
                                 class="w3-check" 
                                 type="checkbox"
-                                @change="changePasswordProtected($event)">
+                                @change="changePasswordRequired($event)">
                             <label for="is-password-protected">Zabezpieczenie hasłem</label>
-                            <p v-if="passwordProtected" >
+                            <p v-if="passwordRequired" >
                                 Hasło: <input type="text" minlength="5" v-model="settings.password">
                             </p>
-                            <div v-if="6 > settings.password.length && passwordProtected" style="text-align: center;">
+                            <div v-if="6 > settings.password.length && passwordRequired" style="text-align: center;">
                                 <p style="color: red; font-style: italic; margin-top: 0">
                                     Hasło musi być dłuższe niż 5 znaków.
                                 </p>

--- a/blankiety_galantow/resources/game/index.html
+++ b/blankiety_galantow/resources/game/index.html
@@ -53,15 +53,6 @@
                     <p>
                         Hasło: <input id="password" type="text" minlength="5" v-model="inputPassword">
                     </p>
-                    <div v-if="!passwordValid" style="text-align: center;">
-                        <p style="color: red; font-style: italic; margin-top: 0">
-                            Hasło musi być dłuższe niż 5 znaków.
-                        </p>
-                    </div>
-
-                    <p class="w3-card">
-                        <img id="stop-meme" src="https://assets3.thrillist.com/v1/image/1655936/1200x630">
-                    </p>
                 </div>
                 <div class="w3-container w3-border-top w3-padding-16 w3-light-grey">
                     <button v-on:click="exit()" type="button" class="w3-button w3-red">Wyjdź</button>

--- a/blankiety_galantow/resources/game/index.html
+++ b/blankiety_galantow/resources/game/index.html
@@ -58,6 +58,10 @@
                             Hasło musi być dłuższe niż 5 znaków.
                         </p>
                     </div>
+
+                    <p class="w3-card">
+                        <img id="stop-meme" src="https://assets3.thrillist.com/v1/image/1655936/1200x630">
+                    </p>
                 </div>
                 <div class="w3-container w3-border-top w3-padding-16 w3-light-grey">
                     <button v-on:click="exit()" type="button" class="w3-button w3-red">Wyjdź</button>
@@ -104,10 +108,10 @@
                                 type="checkbox"
                                 @change="changePasswordRequired($event)">
                             <label for="is-password-protected">Zabezpieczenie hasłem</label>
-                            <p v-if="passwordRequired" >
-                                Hasło: <input type="text" minlength="5" v-model="settings.password">
+                            <p v-if="settingsPasswordRequired" >
+                                Hasło: <input type="text" minlength="5" v-model="newSettings.password">
                             </p>
-                            <div v-if="6 > settings.password.length && passwordRequired" style="text-align: center;">
+                            <div v-if="6 > newSettings.password.length && settingsPasswordRequired" style="text-align: center;">
                                 <p style="color: red; font-style: italic; margin-top: 0">
                                     Hasło musi być dłuższe niż 5 znaków.
                                 </p>

--- a/blankiety_galantow/resources/game/js/main.js
+++ b/blankiety_galantow/resources/game/js/main.js
@@ -178,6 +178,18 @@ const app = new Vue({
         } ,
         finalCountdown: function() {
             return this.timer < 10 && this.timer > 0;
+        },
+        passwordValid: function() {
+            if(this.passwordProtected){
+                if(this.settings.password != undefined){
+                    if(this.settings.password.length > 5){
+                        return true;
+                    }
+                    return false;
+                }
+                return false;
+            }
+            return true;
         }
     },
     watch: {
@@ -202,8 +214,10 @@ const app = new Vue({
             customCards: 5,
             open: true,
             time: 60,
-            gameType: "default"
+            gameType: "default",
+            password: "asdaw",
         },
+        passwordProtected: false,
         showPlayers: false,
         showChat: true,
         showSettings: false,
@@ -224,7 +238,6 @@ setInterval(()=>{
         app.timer = app.timer - 1;
     }
 }, 1000)
-
 
 // Receive message from websocket
 socket.onmessage = function(event) {

--- a/blankiety_galantow/resources/game/js/main.js
+++ b/blankiety_galantow/resources/game/js/main.js
@@ -108,8 +108,25 @@ const app = new Vue({
             socket.send(JSON.stringify(data));
             this.showSettings = false  // close settings modal
         },
+        submitPassword: function() {
+            if(this.passwordValid)
+            {
+                const data = {
+                    type: "PASSWORD",
+                    password: this.inputPassword
+                };
+                socket.send(JSON.stringify(data));
+                this.passwordRequired = false  // close password modal
+            }
+        },
         updateTimer: function() {
             this.timer = this.settings.time;
+        },
+        changePasswordProtected: function(event) {
+            if(this.passwordProtected){
+                this.settings.password = "";
+            }
+            this.passwordProtected = !this.passwordProtected
         }
     },
     computed: {
@@ -180,17 +197,12 @@ const app = new Vue({
             return this.timer < 10 && this.timer > 0;
         },
         passwordValid: function() {
-            if(this.passwordProtected){
-                if(this.settings.password != undefined){
-                    if(this.settings.password.length > 5){
-                        return true;
-                    }
-                    return false;
-                }
-                return false;
+            if(this.inputPassword.length > 5){
+                return true;
             }
-            return true;
-        }
+            return false;
+        },
+
     },
     watch: {
         chat: function() {
@@ -217,6 +229,8 @@ const app = new Vue({
             gameType: "default",
             password: "asdaw",
         },
+        inputPassword: "",
+        passwordRequired: false,
         passwordProtected: false,
         showPlayers: false,
         showChat: true,
@@ -246,6 +260,9 @@ socket.onmessage = function(event) {
         console.error("Received incorrect message:");
         console.error(data);
         return;
+    }
+    if(data.type === "PASSWORD"){
+        app.passwordRequired = true;
     }
     if(data.type === "CHAT_MESSAGE" && data.message) {
         addMessageToChat(data.message);

--- a/blankiety_galantow/resources/game/js/main.js
+++ b/blankiety_galantow/resources/game/js/main.js
@@ -226,6 +226,7 @@ const app = new Vue({
         },
         settingsPasswordRequired: false,
         passwordRequired: false,
+        passwordLength: 3,
         inputPassword: "",
         newSettings: {},
         showPlayers: false,

--- a/blankiety_galantow/resources/game/js/main.js
+++ b/blankiety_galantow/resources/game/js/main.js
@@ -127,10 +127,10 @@ const app = new Vue({
             this.timer = this.settings.time;
         },
         changePasswordRequired: function(event) {
-            if(this.passwordRequired){
+            if(this.settingsPasswordRequired){
                 this.settings.password = "";
             }
-            this.passwordRequired = !this.passwordRequired
+            this.settingsPasswordRequired = !this.settingsPasswordRequired
         }
     },
     computed: {
@@ -233,6 +233,7 @@ const app = new Vue({
             gameType: "default",
             password: "",
         },
+        settingsPasswordRequired: false,
         passwordRequired: false,
         inputPassword: "",
         newSettings: {},

--- a/blankiety_galantow/resources/game/js/main.js
+++ b/blankiety_galantow/resources/game/js/main.js
@@ -122,11 +122,11 @@ const app = new Vue({
         updateTimer: function() {
             this.timer = this.settings.time;
         },
-        changePasswordProtected: function(event) {
-            if(this.passwordProtected){
+        changePasswordRequired: function(event) {
+            if(this.passwordRequired){
                 this.settings.password = "";
             }
-            this.passwordProtected = !this.passwordProtected
+            this.passwordRequired = !this.passwordRequired
         }
     },
     computed: {
@@ -227,11 +227,10 @@ const app = new Vue({
             open: true,
             time: 60,
             gameType: "default",
-            password: "asdaw",
+            password: "",
         },
-        inputPassword: "",
         passwordRequired: false,
-        passwordProtected: false,
+        inputPassword: "",
         showPlayers: false,
         showChat: true,
         showSettings: false,

--- a/blankiety_galantow/resources/game/js/main.js
+++ b/blankiety_galantow/resources/game/js/main.js
@@ -109,15 +109,12 @@ const app = new Vue({
             this.showSettings = false  // close settings modal
         },
         submitPassword: function() {
-            if(this.passwordValid)
-            {
-                const data = {
-                    type: "PASSWORD",
-                    password: this.inputPassword
-                };
-                socket.send(JSON.stringify(data));
-                this.passwordRequired = false  // close password modal
-            }
+            const data = {
+                type: "PASSWORD",
+                password: this.inputPassword
+            };
+            socket.send(JSON.stringify(data));
+            this.passwordRequired = false  // close password modal
         },
         cancelSettingsChanges: function() {
             this.newSettings = Object.assign({}, this.settings);
@@ -199,12 +196,6 @@ const app = new Vue({
         } ,
         finalCountdown: function() {
             return this.timer < 10 && this.timer > 0;
-        },
-        passwordValid: function() {
-            if(this.inputPassword.length > 5){
-                return true;
-            }
-            return false;
         },
 
     },


### PR DESCRIPTION
# Ustawianie hasła (idoczne tylko dla admina)
## 1
![image](https://user-images.githubusercontent.com/37443550/83547788-070d0480-a503-11ea-87ff-2b38263737a8.png)
## 2 (jest dodana prosta walidacja, która sprawdza, czy hasło ma więcej niż 5 liter)
![image](https://user-images.githubusercontent.com/37443550/83547817-0ffdd600-a503-11ea-8de1-6eb4dd5c04f4.png)
## 3 (Fajne jest to, że na windowsie w haśle można dodać emotikonki 😉)
![image](https://user-images.githubusercontent.com/37443550/83547853-1db35b80-a503-11ea-8443-bd0acd730f8e.png)

# Teraz pozostali gracze po wejściu na serwer dostają modala do podania hasła
![image](https://user-images.githubusercontent.com/37443550/83547892-2a37b400-a503-11ea-876b-a2b2720d6f8e.png)

## Tu też jest prosta walidacja hasła, czyli sprawdzenie, czy jest więcej niż 5 liter
![image](https://user-images.githubusercontent.com/37443550/83547921-37ed3980-a503-11ea-9cd9-9da84ecf4b5e.png)

## Jak hasło jest niepoprawne to wyrzuca gracza z serwera
![image](https://user-images.githubusercontent.com/37443550/83547947-3f144780-a503-11ea-890b-79ed4db42d8b.png)
