### PR TITLE
fix kick announcement #87

### DIFF
--- a/blankiety_galantow/core/game_master.py
+++ b/blankiety_galantow/core/game_master.py
@@ -118,7 +118,8 @@ class GameMaster:
                 await self.select_random_player_cards(player)
                 player.rounds_without_activity = player.rounds_without_activity + 1
                 if player.rounds_without_activity > 2:
-                    await player.kick("Brak aktywności.")
+                    await self.chat.send_message_from_system(f"Gracz '{player.name}' został usunięty za brak aktywności.")
+                    await player.kick("Brak aktywności")
             elif player.state == PlayerState.ready:
                 player.rounds_without_activity = 0
 
@@ -176,6 +177,7 @@ class GameMaster:
         Method for handling CARDS_SELECT message
         """
         if not self.player_owns_cards(player, data["cards"]):
+            await self.chat.send_message_from_system(f"Gracz '{player.name}' został usunięty za próbę oszustwa.")
             await player.kick("Próba oszustwa")
             return
         self.select_cards(player, data["cards"])

--- a/blankiety_galantow/core/player.py
+++ b/blankiety_galantow/core/player.py
@@ -1,5 +1,5 @@
 from json import JSONDecodeError
-from fastapi import WebSocket
+from fastapi import WebSocket, status
 from fastapi.websockets import WebSocketDisconnect
 from .kick_exception import KickException
 from enum import Enum
@@ -57,6 +57,7 @@ class Player:
             ]
         }
         await self.send_json(message)
+
         
     async def kick(self, reason: str):
         kick_reason = {
@@ -65,7 +66,6 @@ class Player:
         }
         await self.send_json(kick_reason)
         await self.socket.close()
-        raise KickException(f"Gracz '{self.name}'' został wyrzucony z pokoju. Powód: {reason}")
 
     async def receive_json(self):
         """Await for incoming message from the player."""

--- a/blankiety_galantow/core/room.py
+++ b/blankiety_galantow/core/room.py
@@ -101,9 +101,6 @@ class Room:
         except WebSocketDisconnect:
             await self.players.remove(player)
             await self.handle_player_leaving(player)
-        except KickException as ex:
-            await self.players.remove(player)
-            await self.handle_player_leaving(player, message=ex.message)
 
     async def process_message(self, player: Player, data: Dict):
         """Process raw JSON message (data) from player."""


### PR DESCRIPTION
zrobiłam poprawne wyświetlanie informacji o wykopaniu gracza. Być może kontrowersyjną kwestią będzie zrezygnowaie z rzucania wyjątku `KickException`, ale prawda jest taka, że wcześniejsze wywołanie `socket.close()` powodowało rzucenie wyjątku `WebSocketDisconnect` i `KickException` stawał się bezużyteczny. Być może jest rozwiązanie tego problemu używające `KickException`, lecz ja na nie nie wpadłam. Rozwiązanie zawarte w tym PR wydaje mi się być najmniej bolesne. Jeżeli macie pomysł, jak to ulepszyć/wykorzystać jednak `KickException`, dajcie proszę znać.