### PR TITLE
Remove unnecessary destructor and update requirements.txt

### DIFF
--- a/blankiety_galantow/core/game_master.py
+++ b/blankiety_galantow/core/game_master.py
@@ -47,7 +47,7 @@ class GameMaster:
         await self.send_timer_message(player)
     
     async def handle_player_leave(self, player):
-        if len(self.players) < 2 and self.timer is not None:
+        if len(self.players) < 2 and self.is_timer_set():
             self.timer.cancel()
         if player is self.master:
             self.set_new_random_master()

--- a/blankiety_galantow/core/room.py
+++ b/blankiety_galantow/core/room.py
@@ -22,9 +22,6 @@ class Room:
         self.settings.name = name
         self.admin = None
 
-    def __del__(self):
-        self.game_master.timer.cancel()
-
     @property
     def number_of_players(self):
         return len(self.players)
@@ -33,7 +30,7 @@ class Room:
     def is_empty(self):
         return self.number_of_players == 0
 
-    async def connect_new_player(self, player: Player):
+    async def connect_new_player_and_listen(self, player: Player):
         """Add new player to the room and start listening."""
         if not self.settings.open:
             await player.kill("Pokój jest zamknięty.")

--- a/blankiety_galantow/core/server.py
+++ b/blankiety_galantow/core/server.py
@@ -17,7 +17,7 @@ class Server:
 
     async def add_player_to_room(self, room_id: int, player: Player):
         """Add new player to existing room."""
-        await self._rooms[room_id].connect_new_player(player)
+        await self._rooms[room_id].connect_new_player_and_listen(player)
         self.delete_if_empty(room_id)
 
     def add_room(self, name: str, seats: int = 0):

--- a/blankiety_galantow/core/utils/timer.py
+++ b/blankiety_galantow/core/utils/timer.py
@@ -6,12 +6,10 @@ class Timer:
         self._timeout = timeout
         self._callback = callback
         self.task = asyncio.ensure_future(self._job())
-                
 
     async def _job(self):
         await asyncio.sleep(self._timeout)
         await self._callback()
-
 
     def cancel(self):
         self.task.cancel()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ click==7.1.2
 fastapi==0.65.2
 h11==0.9.0
 pydantic==1.6.2
-starlette==0.13.2
 uvicorn==0.11.7
 websockets==8.1
 asyncio==3.4.3


### PR DESCRIPTION
Fix #129 

Usunąłem destruktor, bo wyłączanie timera jest już robione w funkcji `handle_player_leave` w GameMaster (która wywołuje się za każdym razem, gdy usuwamy playera z listy `self.players`:
```
    async def handle_player_leave(self, player):
        if len(self.players) < 2 and self.is_timer_set():
            self.timer.cancel()
        if player is self.master:
       ...
```

Możliwe, że są sytuacje, gdzie ta funkcja powinna być wywoływana, a nie jest (i wtedy trzeba to naprawić), ale w takim razie trzymanie dłużej tego konstruktora tylko zakrywałoby nam inne bugi.